### PR TITLE
Chore: Add rule in jshint to disable var keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "unused": true,
       "browser": true,
       "mocha": true,
-      "node": true
+      "node": true,
+      "varstmt": true
    },
    "scripts": {
       "pretest": "jshint *.js && gulp lint-html && gulp build-dist",


### PR DESCRIPTION
Hi,

This PR resolve the issue #33. This was the result after apply this change to validate the use of the rule:

I added in the line 8 a var declaration (this is an example, not is a part of this PR) and run the command jshint in the terminal
![image](https://user-images.githubusercontent.com/43805357/95671657-2413ad00-0b5f-11eb-8ead-b7e00f6d9524.png)

Let me know if there is any change to do.